### PR TITLE
Adapted plugin to recaptcha V2. api.js is now automatically loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Try the add-on demo at http://demo.webstar.hu/vaadin-recaptcha
 ## Usage
 
 1. Create your keys at http://www.google.com/recaptcha
-2. Include recaptcha javascript ajax api in your application. 
+2. (Optional) Include recaptcha javascript ajax api in your application.
     Simplest way is annotating your UI, or a parent component:
     ````
     @JavaScript("http://www.google.com/recaptcha/api/js/recaptcha_ajax.js")
@@ -43,7 +43,7 @@ See [DummyRegWithReCaptcha.java](vaadin-recaptcha-demo/src/main/java/com/wcs/wcs
 
 ## Documentation
 
-For ReCaptcha options see: https://developers.google.com/recaptcha/old/docs/customization.
+For ReCaptcha options see: https://developers.google.com/recaptcha/docs/display.
 
 ## Known Issues and limitations
 
@@ -52,5 +52,3 @@ For ReCaptcha options see: https://developers.google.com/recaptcha/old/docs/cust
 2. The javascript api does not support more recaptcha on one page.
 
 3. The javascript api does not suport changing options (like theme, or language) on the same page. Once a component is rendered, all other components inherit the options, until page reload.
-
-

--- a/vaadin-recaptcha/src/main/java/com/wcs/wcslib/vaadin/widget/recaptcha/shared/ReCaptchaOptions.java
+++ b/vaadin-recaptcha/src/main/java/com/wcs/wcslib/vaadin/widget/recaptcha/shared/ReCaptchaOptions.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
  */
 public class ReCaptchaOptions implements Serializable {
 
+    public String sitekey;
     public String lang;
     public String theme;
     public String custom_theme_widget;

--- a/vaadin-recaptcha/src/main/java/com/wcs/wcslib/vaadin/widget/recaptcha/shared/ReCaptchaState.java
+++ b/vaadin-recaptcha/src/main/java/com/wcs/wcslib/vaadin/widget/recaptcha/shared/ReCaptchaState.java
@@ -19,8 +19,6 @@ import com.vaadin.shared.ui.JavaScriptComponentState;
 
 public class ReCaptchaState extends JavaScriptComponentState {
 
-    public String publicKey;
-
     public String customHtml;
 
     public ReCaptchaOptions options;

--- a/vaadin-recaptcha/src/main/resources/com/wcs/wcslib/vaadin/widget/recaptcha/recaptcha-connector.js
+++ b/vaadin-recaptcha/src/main/resources/com/wcs/wcslib/vaadin/widget/recaptcha/recaptcha-connector.js
@@ -16,28 +16,61 @@
 
 window.com_wcs_wcslib_vaadin_widget_recaptcha_ReCaptcha =
 function() {
-    var element = this.getElement();
+	
+	var element = this.getElement();
+	var connector = this;
+	
+	this.onStateChange = function() {
+		this.stateChangedDuringLoad = true;
+	}
+	
+    var init = function(){
+	    this.onStateChange = function() {
+	        var state = this.getState();
+	        var html, elementId;
+	        if (state.customHtml) {
+	            html = state.customHtml;
+	            elementId = null;
+	        } else {
+	            html = '<div id="recaptcha_div"></div>';
+	            elementId = "recaptcha_div";
+	        }
+	        element.innerHTML = html;
+	        
+	        //Add callback to grecaptcha options to force server update on user input
+	        state.options['callback'] = function(){
+	        	connector.responseChanged(grecaptcha.getResponse());
+        	};
+        	
+        	//Add expired-callback to reload component automatically
+        	state.options['expired-callback'] = this.reload;
+        	
+	        grecaptcha.render(elementId, state.options);
+	    };
+	    
+	    this.reload = function() {
+	    	grecaptcha.reset();
+	    };
 
-    this.onStateChange = function() {
-        var state = this.getState();
-        var html, elementId;
-        if (state.customHtml) {
-            html = state.customHtml;
-            elementId = null;
-        } else {
-            html = '<div id="recaptcha_div"></div>';
-            elementId = "recaptcha_div";
-        }
-        element.innerHTML = html;
-        Recaptcha.create(state.publicKey, elementId, state.options);
-    };
+    }.bind(this);
     
-    this.reload = function() {
-        Recaptcha.reload();
-    };
-
-    var connector = this;
-    element.onchange = function() {
-        connector.responseChanged(Recaptcha.get_challenge(), Recaptcha.get_response());
-    };
+    //Global scope to enable call outside this script.
+    recaptchaVaadinOnLoadCallBack = function(){
+    	init();
+    	//Vaadin may update the component while recaptcha is loading in parallel. We will init the component if that happened
+    	if(this.stateChangedDuringLoad){
+    		this.onStateChange();
+    	};
+    }.bind(this);
+    
+    //We are checking if recaptcha is already on the window context. We will either init the component or load recaptcha
+    if(window['grecaptcha']){
+    	init();
+    }
+    else{
+    	var recaptchaImport = document.createElement('script');
+    	//We are passing the "onload" parameter to enable the component rendering after recaptcha has been loaded
+    	recaptchaImport.src = 'https://www.google.com/recaptcha/api.js?onload=recaptchaVaadinOnLoadCallBack&render=explicit';
+    	document.getElementsByTagName('head')[0].appendChild(recaptchaImport);
+    }
 };


### PR DESCRIPTION
Hi, I adapted the plugin to support the V2 version of recaptcha.
Main changes regarding previous recaptcha api are:
- publicKey (now called siteKey) must be in the javascript options
- Recaptcha object was renamed to grecaptcha
- recaptcha functions were renamed
- There is no challenge, the service is able to do everything only with the client response

I made another feature which is making the "api.js" automatic. When the widget starts, it checks if the grecaptcha object is in the javascript context, if not, it starts loading the api.js and will only initialize the widget after recaptcha is present.

Another problem is the fact that recaptcha4j has not been updated in years. The server validation was used without the recaptcha4j API. Altough, they have a simple http facade which I used, so the dependency was not totally removed, but I suggest removing it in the future.